### PR TITLE
Update inactive URLs in documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -348,3 +348,9 @@ The instructions from these files are now included in this file.
 
 By following these rules, GitHub Copilot will create code that is easier to understand and maintain. Keeping things simple and using good practices will help make the code strong and reliable for everyone.
 
+## Further Reading on Documentation Standards and Tools
+
+For more information on documentation standards and tools, refer to the following resources:
+
+- [TypeDoc Overview](https://typedoc.org/guides/overview/)
+- [TSDoc](https://tsdoc.org/)

--- a/README.md
+++ b/README.md
@@ -76,8 +76,15 @@ Current project status and progress are tracked in:
 - Review `cline.md` for AI agent guidelines
 - Refer to `.github/copilot-instructions.md` for GitHub Copilot instructions and preferences
 
+### Documentation Tools
+
+- [TypeDoc Overview](https://typedoc.org/guides/overview/)
+- [TSDoc](https://tsdoc.org/)
+
+### Inactive URLs
+
+- The link to `library/README.md` is currently inactive and will be updated in the future.
 
 ## GitHub Copilot Instructions
 
 GitHub Copilot has completed a comprehensive awareness scan and cataloged all relevant project files and directories. For detailed instructions, please refer to [copilot.md](copilot.md).
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,7 @@ This directory contains shell scripts for managing the environment, verification
 ## Documentation Navigation
 
 - [↑ Project Root](../README.md): Main project documentation
-- [→ Library](../library/README.md): Python implementation
+- [→ Library](../library/README.md): Python implementation (currently inactive, will be updated in the future)
 - [→ Source](../src/README.md): TypeScript implementation
 
 ## Available Scripts
@@ -91,7 +91,7 @@ This directory contains shell scripts for managing the environment, verification
 
 These scripts support the integration between:
 
-- [Python library](../library/README.md) components
+- [Python library](../library/README.md) components (currently inactive, will be updated in the future)
 - [TypeScript implementation](../src/README.md)
 
 ## Additional Resources


### PR DESCRIPTION
Add explanations for inactive URLs in documentation files.

* **README.md**
  - Add explanation for inactive URL to `library/README.md` in the "Additional Resources" section.
  - Mark the inactive URL to `library/README.md` as a placeholder for future documentation updates.

* **scripts/README.md**
  - Add explanation for inactive URL to `../library/README.md` in the "Documentation Navigation" section.
  - Mark the inactive URL to `../library/README.md` as a placeholder for future documentation updates.

* **.github/copilot-instructions.md**
  - Add a section under "Writing Documentation" to include the two URLs as references for further reading on documentation standards and tools.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Luxcium/image-pipeline/pull/4?shareId=c68391a0-6cc2-48a8-a8a8-d01a38bf220a).